### PR TITLE
Additional log about unexpected package name in package.json

### DIFF
--- a/findPackage.js
+++ b/findPackage.js
@@ -23,7 +23,10 @@ const findPackage = function(packageName, searchPath) {
         } catch (err) {
           return;
         }
-        if (pkg.name != packageName) return;
+        if (pkg.name != packageName) {
+            console.log(`wrong package name in ${path.join(dirname, basename)}: actual=${pkg.name}, expected=${packageName}`);
+            return;
+        }
         finder.stop();
         resolve({ dirname, pkg, file });
       }


### PR DESCRIPTION
This change needs to any developer have an ability to understand what going wrong in "find package" step in Azure Pipelines, like that https://dev.azure.com/openupm/openupm/_build/results?view=logs&buildId=39126&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=0db80ebc-3da9-5105-8df1-43c3063dee76