### PR TITLE
Skip Azure e2e when PAT is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,20 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-      - name: npm ci
-        run: npm ci
       - name: Check Azure PAT
+        id: azure-pat
         run: |
           if [ -z "${AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE:-}" ]; then
-            echo "AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE is required for Azure E2E."
-            exit 1
+            echo "AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE is not configured; skipping Azure E2E."
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: npm ci
+        if: steps.azure-pat.outputs.has_token == 'true'
+        run: npm ci
       - name: Run Azure git e2e fixture
+        if: steps.azure-pat.outputs.has_token == 'true'
         run: |
           node scripts/runAzureFixture.js \
             --source-branch "$SOURCE_BRANCH" \
@@ -56,6 +61,7 @@ jobs:
             --package-version "1.0.1" \
             --package-source "git"
       - name: Run Azure GitHub Release asset e2e fixture
+        if: steps.azure-pat.outputs.has_token == 'true'
         env:
           ASSET_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/test/fixtures/assets/com.example.release-asset-1.0.0.tgz
         run: |


### PR DESCRIPTION
## Summary

Make the Azure E2E GitHub Actions job skip its Azure-specific setup and fixture runs when `AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE` is unavailable.

This keeps normal PR validation useful for contexts where repository secrets are not exposed, while still running the Azure fixtures when the token is configured.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
