### PR TITLE
Require Azure e2e token for trusted refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE: ${{ secrets.AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE }}
       SOURCE_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      AZURE_E2E_ALLOW_MISSING_TOKEN: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -42,6 +43,10 @@ jobs:
         id: azure-pat
         run: |
           if [ -z "${AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE:-}" ]; then
+            if [ "${AZURE_E2E_ALLOW_MISSING_TOKEN:-false}" != "true" ]; then
+              echo "AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE is required for Azure E2E in this repository."
+              exit 1
+            fi
             echo "AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE is not configured; skipping Azure E2E."
             echo "has_token=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Tightens the Azure E2E skip behavior from PR #22:

- missing `AZURE_DEVOPS_TOKEN_OPENUPM_PIPELINE` still skips Azure E2E for fork PRs, where secrets are not available
- missing token now fails for trusted refs: same-repo PRs and branch pushes in `openupm/openupm-pipelines`

This keeps external PR validation usable without weakening required Azure E2E coverage for repository-owned changes.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
