### PR TITLE
fix: accept BOM in package manifests

### DIFF
--- a/createPackageArtifactMetadata.js
+++ b/createPackageArtifactMetadata.js
@@ -1,6 +1,7 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const { readPackageJson } = require("./lib/packageJson");
 
 /**
  * @param {string} filePath
@@ -31,7 +32,7 @@ const createPackageArtifactMetadata = function (
   distTag,
 ) {
   const packageJsonPath = path.resolve(packageFolder, "package.json");
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const packageJson = readPackageJson(packageJsonPath);
   const resolvedTarballPath = path.resolve(tarballPath);
 
   return {

--- a/findPackage.js
+++ b/findPackage.js
@@ -4,15 +4,7 @@ const findit = require("findit2");
 const path = require("path");
 const relative = require("relative");
 const { logDebug, logError } = require("./lib/logger");
-
-/**
- * @param {string} filePath
- * @returns {{name?: string}}
- */
-const readPackageJson = function (filePath) {
-  const raw = fs.readFileSync(filePath, "utf8");
-  return JSON.parse(raw);
-};
+const { readPackageJson } = require("./lib/packageJson");
 
 /**
  * @param {string} packageName

--- a/lib/packageJson.js
+++ b/lib/packageJson.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+const stripLeadingBom = function (text) {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+};
+
+/**
+ * @param {string} text
+ * @returns {{name?: string, version?: string}}
+ */
+const parsePackageJsonText = function (text) {
+  return JSON.parse(stripLeadingBom(text));
+};
+
+/**
+ * @param {string} filePath
+ * @returns {{name?: string, version?: string}}
+ */
+const readPackageJson = function (filePath) {
+  return parsePackageJsonText(fs.readFileSync(filePath, "utf8"));
+};
+
+module.exports = {
+  parsePackageJsonText,
+  readPackageJson,
+  stripLeadingBom,
+};

--- a/test/test-createPackageArtifactMetadata.js
+++ b/test/test-createPackageArtifactMetadata.js
@@ -54,4 +54,24 @@ describe("createPackageArtifactMetadata.js", function () {
       signed: false,
     });
   });
+
+  it("creates artifact metadata from package.json with a UTF-8 BOM", function () {
+    const packageDir = path.join(tmpDir, "pkg");
+    const tarballPath = path.join(packageDir, "package-a-1.0.0.tgz");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      '\uFEFF{"name":"package-a","version":"1.0.0"}\n',
+    );
+    fs.writeFileSync(tarballPath, "tarball-content");
+
+    const metadata = createPackageArtifactMetadata(
+      packageDir,
+      tarballPath,
+      "latest",
+    );
+
+    metadata.packageName.should.equal("package-a");
+    metadata.packageVersion.should.equal("1.0.0");
+  });
 });

--- a/test/test-findPackage.js
+++ b/test/test-findPackage.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 require("should");
+const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const {
@@ -25,6 +26,14 @@ describe("findPackage.js", function () {
         name: "package-a",
       });
       const result = await findPackage("package-a", tmpDir);
+      result.pkg.name.should.equal("package-a");
+    });
+    it("finds package.json with a UTF-8 BOM", async function () {
+      const packageJsonPath = path.resolve(tmpDir, "package.json");
+      fs.writeFileSync(packageJsonPath, '\uFEFF{"name":"package-a"}\n');
+
+      const result = await findPackage("package-a", tmpDir);
+
       result.pkg.name.should.equal("package-a");
     });
     it("find failed", async function () {


### PR DESCRIPTION
## Summary
- add a shared package.json reader that strips a leading UTF-8 BOM before parsing
- use it for package discovery and artifact metadata generation
- add BOM regression coverage for both paths

Closes openupm/openupm#4135

## Validation
- npm test
- npm run lint
- npm run format:check
- npm run typecheck