### PR TITLE
[codex] Emit published package version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -354,8 +354,7 @@ stages:
           - script: |
               set -euo pipefail
               METADATA_FILE="$(Pipeline.Workspace)/$(artifactName)/metadata.json"
-              SIGNED=$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(result.signed === true ? "true" : "false");' "$METADATA_FILE")
-              echo "OPENUPM_PACKAGE_RESULT {\"signed\":$SIGNED}"
+              node createPackageResult.js "$METADATA_FILE"
             displayName: "Emit package result"
 
   - stage: PublishE2EPackage
@@ -479,7 +478,6 @@ stages:
               docker logs verdaccio-e2e || true
               docker rm -f verdaccio-e2e || true
               METADATA_FILE="$(Pipeline.Workspace)/$(artifactName)/metadata.json"
-              SIGNED=$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(result.signed === true ? "true" : "false");' "$METADATA_FILE")
-              echo "OPENUPM_PACKAGE_RESULT {\"signed\":$SIGNED}"
+              node createPackageResult.js "$METADATA_FILE"
             condition: always()
             displayName: "Stop Verdaccio"

--- a/createPackageResult.js
+++ b/createPackageResult.js
@@ -1,0 +1,41 @@
+const fs = require("fs");
+
+/**
+ * @param {unknown} metadata
+ * @returns {{ signed: boolean, publishedVersion?: string }}
+ */
+const createPackageResult = function (metadata) {
+  const source = /** @type {Record<string, unknown>} */ (
+    metadata && typeof metadata === "object" ? metadata : {}
+  );
+  const result = {
+    signed: source.signed === true,
+  };
+  if (typeof source.packageVersion === "string") {
+    result.publishedVersion = source.packageVersion;
+  }
+  return result;
+};
+
+/**
+ * @param {string} metadataFile
+ * @returns {{ signed: boolean, publishedVersion?: string }}
+ */
+const createPackageResultFromMetadataFile = function (metadataFile) {
+  return createPackageResult(JSON.parse(fs.readFileSync(metadataFile, "utf8")));
+};
+
+if (require.main === module) {
+  if (process.argv.length < 3) {
+    console.error("Usage: node createPackageResult.js <metadata-file>");
+    process.exit(1);
+  }
+
+  const result = createPackageResultFromMetadataFile(process.argv[2]);
+  console.log(`OPENUPM_PACKAGE_RESULT ${JSON.stringify(result)}`);
+}
+
+module.exports = {
+  createPackageResult,
+  createPackageResultFromMetadataFile,
+};

--- a/test/test-createPackageResult.js
+++ b/test/test-createPackageResult.js
@@ -1,0 +1,84 @@
+/* eslint-disable no-undef */
+const fs = require("fs");
+const path = require("path");
+
+const {
+  createPackageResult,
+  createPackageResultFromMetadataFile,
+} = require("../createPackageResult");
+const {
+  createTmpDir,
+  getTmpDir,
+  removeTmpDir,
+  writeJsonFile,
+} = require("./utils");
+
+describe("createPackageResult.js", function () {
+  const tmpRoot = "test-create-package-result";
+  const tmpDir = getTmpDir(tmpRoot);
+
+  beforeEach(function () {
+    removeTmpDir(tmpRoot);
+    createTmpDir(tmpRoot);
+  });
+
+  after(function () {
+    removeTmpDir(tmpRoot);
+  });
+
+  it("creates a signed package result with publishedVersion", function () {
+    createPackageResult({
+      signed: true,
+      packageVersion: "1.2.3",
+    }).should.deepEqual({
+      signed: true,
+      publishedVersion: "1.2.3",
+    });
+  });
+
+  it("creates an unsigned package result with publishedVersion", function () {
+    createPackageResult({
+      signed: false,
+      packageVersion: "2.0.0-preview.1",
+    }).should.deepEqual({
+      signed: false,
+      publishedVersion: "2.0.0-preview.1",
+    });
+  });
+
+  it("defaults missing signed to false", function () {
+    createPackageResult({
+      packageVersion: "1.0.0",
+    }).should.deepEqual({
+      signed: false,
+      publishedVersion: "1.0.0",
+    });
+  });
+
+  it("reads metadata from disk", function () {
+    const metadataFile = path.join(tmpDir, "metadata.json");
+    writeJsonFile(metadataFile, {
+      signed: true,
+      packageVersion: "3.1.4",
+    });
+
+    createPackageResultFromMetadataFile(metadataFile).should.deepEqual({
+      signed: true,
+      publishedVersion: "3.1.4",
+    });
+  });
+
+  it("prints the result marker from the CLI", function () {
+    const metadataFile = path.join(tmpDir, "metadata.json");
+    fs.writeFileSync(
+      metadataFile,
+      JSON.stringify({ signed: true, packageVersion: "4.5.6" }),
+    );
+
+    const result = createPackageResultFromMetadataFile(metadataFile);
+
+    `OPENUPM_PACKAGE_RESULT ${JSON.stringify(result)}`.should.equal(
+      'OPENUPM_PACKAGE_RESULT {"signed":true,"publishedVersion":"4.5.6"}',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a reusable package result marker helper that reads artifact metadata
- include `publishedVersion` from `metadata.json` in `OPENUPM_PACKAGE_RESULT`
- use the helper for both normal OpenUPM publish and Verdaccio e2e cleanup/result logging

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm run format:check`