### PR TITLE
[codex] validate package manifest version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,6 +204,7 @@ stages:
               node findPackage.js "$(packageName)" "$(repoDir)" result.json
               PACKAGEFOLDER=$(node -e 'const fs=require("fs"); const result=JSON.parse(fs.readFileSync("result.json","utf8")); console.log(result.dirname);')
               echo "PACKAGEFOLDER: $PACKAGEFOLDER"
+              node validatePackageManifest.js "$PACKAGEFOLDER" "$(packageName)" "$(packageVersion)"
               echo "##vso[task.setvariable variable=packageFolder;]$PACKAGEFOLDER"
             displayName: "Detect package.json location"
             condition: eq(variables['packageSourceMode'], 'git')

--- a/createPackageArtifactMetadataFromTarball.js
+++ b/createPackageArtifactMetadataFromTarball.js
@@ -121,7 +121,7 @@ const createPackageArtifactMetadataFromTarball = function (
   }
   if (packageJson.version !== expectedPackageVersion) {
     throw new Error(
-      `Downloaded package asset version mismatch: actual=${packageJson.version}, expected=${expectedPackageVersion}`,
+      `Downloaded package asset version mismatch: package.json.version=${packageJson.version}, expectedReleaseVersion=${expectedPackageVersion}`,
     );
   }
 

--- a/test/test-validatePackageManifest.js
+++ b/test/test-validatePackageManifest.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-undef */
+require("should");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const {
+  getTmpDir,
+  createTmpDir,
+  removeTmpDir,
+  writeJsonFile,
+} = require("./utils");
+const { validatePackageManifest } = require("../validatePackageManifest");
+
+describe("validatePackageManifest.js", function () {
+  const tmpDir = getTmpDir("test-validate-package-manifest");
+
+  beforeEach(function () {
+    removeTmpDir("test-validate-package-manifest");
+    createTmpDir("test-validate-package-manifest");
+  });
+
+  afterEach(function () {
+    removeTmpDir("test-validate-package-manifest");
+  });
+
+  it("accepts a matching package manifest", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+    });
+
+    const result = validatePackageManifest(tmpDir, "package-a", "1.0.0");
+
+    result.name.should.equal("package-a");
+    result.version.should.equal("1.0.0");
+  });
+
+  it("rejects a mismatched package version", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.1",
+    });
+
+    (() => validatePackageManifest(tmpDir, "package-a", "1.0.0")).should.throw(
+      "Package manifest version mismatch: package.json.version=1.0.1, expectedReleaseVersion=1.0.0",
+    );
+  });
+
+  it("rejects a mismatched package name", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-b",
+      version: "1.0.0",
+    });
+
+    (() => validatePackageManifest(tmpDir, "package-a", "1.0.0")).should.throw(
+      "Package manifest name mismatch: actual=package-b, expected=package-a",
+    );
+  });
+
+  it("accepts a package manifest with a UTF-8 BOM", function () {
+    const packageJsonPath = path.resolve(tmpDir, "package.json");
+    fs.writeFileSync(
+      packageJsonPath,
+      '\uFEFF{"name":"package-a","version":"1.0.0"}\n',
+    );
+
+    const result = validatePackageManifest(tmpDir, "package-a", "1.0.0");
+
+    result.name.should.equal("package-a");
+    result.version.should.equal("1.0.0");
+  });
+
+  it("compares package versions as exact strings", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.2.03",
+    });
+
+    (() => validatePackageManifest(tmpDir, "package-a", "1.2.3")).should.throw(
+      "Package manifest version mismatch: package.json.version=1.2.03, expectedReleaseVersion=1.2.3",
+    );
+  });
+
+  it("cli accepts a matching package manifest", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+    });
+    const scriptPath = path.resolve(
+      __dirname,
+      "..",
+      "validatePackageManifest.js",
+    );
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, tmpDir, "package-a", "1.0.0"],
+      { encoding: "utf8" },
+    );
+
+    result.status.should.equal(0);
+    result.stdout.should.containEql(
+      "Package manifest matches expected package name and version",
+    );
+  });
+});

--- a/validatePackageManifest.js
+++ b/validatePackageManifest.js
@@ -1,0 +1,51 @@
+const path = require("path");
+const { logError } = require("./lib/logger");
+const { readPackageJson } = require("./lib/packageJson");
+
+/**
+ * @param {string} packageFolder
+ * @param {string} expectedPackageName
+ * @param {string} expectedPackageVersion
+ * @returns {{name?: string, version?: string}}
+ */
+const validatePackageManifest = function (
+  packageFolder,
+  expectedPackageName,
+  expectedPackageVersion,
+) {
+  const packageJsonPath = path.join(packageFolder, "package.json");
+  const pkg = readPackageJson(packageJsonPath);
+
+  if (pkg.name !== expectedPackageName) {
+    throw new Error(
+      `Package manifest name mismatch: actual=${pkg.name}, expected=${expectedPackageName}`,
+    );
+  }
+
+  if (pkg.version !== expectedPackageVersion) {
+    throw new Error(
+      `Package manifest version mismatch: package.json.version=${pkg.version}, expectedReleaseVersion=${expectedPackageVersion}`,
+    );
+  }
+
+  return pkg;
+};
+
+if (require.main === module) {
+  if (process.argv.length < 5) {
+    logError(
+      "Usage: node validatePackageManifest.js <package-folder> <expected-package-name> <expected-package-version>",
+    );
+    process.exit(1);
+  }
+
+  try {
+    validatePackageManifest(process.argv[2], process.argv[3], process.argv[4]);
+    console.log("Package manifest matches expected package name and version");
+  } catch (err) {
+    logError(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { validatePackageManifest };


### PR DESCRIPTION
## Summary

- Add `validatePackageManifest.js` for exact package name and version validation after package discovery.
- Run the helper in the git-source pipeline before `npm pack` so mismatched `package.json.version` fails early.
- Use clearer version mismatch log text that reports `package.json.version` and `expectedReleaseVersion`.
- Align GitHub Release asset version mismatch wording with the same rule.

## Impact

Git checkout builds now keep the existing guardrail: the package manifest must match the queued package name and parsed release version. The mismatch text is stable for downstream classification and author-facing diagnostics.

## Validation

- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `node validatePackageManifest.js test/fixtures/release-asset-package com.example.release-asset 1.0.0`