### PR TITLE
Add repository metadata to git package builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,11 +211,17 @@ stages:
 
           - script: |
               set -euo pipefail
+              REPOSITORY_REVISION=$(git -C "$(repoDir)" rev-parse HEAD)
               cd "$(packageFolder)"
+              echo "Patching repository metadata in $(packageFolder)"
+              node "$(Build.SourcesDirectory)/patchPackageRepository.js" \
+                . \
+                "$(repoUrl)" \
+                "$REPOSITORY_REVISION"
               echo "Overriding publishConfig.registry in $(packageFolder)"
               npm pkg set publishConfig.registry="$(publishRegistryUrl)"
               cat package.json
-            displayName: "Override publishConfig"
+            displayName: "Patch package metadata"
             condition: eq(variables['packageSourceMode'], 'git')
 
           - script: |
@@ -470,6 +476,10 @@ stages:
               set -euo pipefail
               echo "Published package metadata from Verdaccio:"
               npm view "$(packageNameFromArtifact)" --registry="$(verdaccioUrl)" --json
+              if [ "${PACKAGESOURCE:-git}" = "git" ]; then
+                REPOSITORY_JSON=$(npm view "$(packageNameFromArtifact)@$(packageVersionFromArtifact)" repository --registry="$(verdaccioUrl)" --json)
+                node -e 'const repo=JSON.parse(process.argv[1]); if (!repo || repo.type !== "git" || typeof repo.url !== "string" || repo.url.length === 0 || typeof repo.revision !== "string" || !/^([0-9a-f]{40}|[0-9a-f]{64})$/.test(repo.revision)) { console.error("Published package repository metadata is invalid"); console.error(JSON.stringify(repo)); process.exit(1); }' "$REPOSITORY_JSON"
+              fi
               echo "Verdaccio storage files:"
               find "$(Pipeline.Workspace)/verdaccio-storage" -type f | sort
             displayName: "Print Verdaccio registry content"

--- a/patchPackageRepository.js
+++ b/patchPackageRepository.js
@@ -1,0 +1,90 @@
+const fs = require("fs");
+const path = require("path");
+const { logError } = require("./lib/logger");
+const { readPackageJson } = require("./lib/packageJson");
+
+/**
+ * @typedef {{type: string, url: string, revision: string}} RepositoryMetadata
+ */
+
+/**
+ * @typedef {{
+ *   [key: string]: unknown,
+ *   name?: string,
+ *   version?: string,
+ *   displayName?: string,
+ *   dependencies?: Record<string, string>,
+ *   repository?: string | (Record<string, unknown> & Partial<RepositoryMetadata>),
+ * }} PackageManifest
+ */
+
+/**
+ * @param {string} value
+ * @param {string} name
+ * @returns {void}
+ */
+const assertNonEmptyString = function (value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} is required`);
+  }
+};
+
+/**
+ * @param {string} packageFolder
+ * @param {string} repoUrl
+ * @param {string} revision
+ * @returns {PackageManifest & {repository: RepositoryMetadata}}
+ */
+const patchPackageRepository = function (packageFolder, repoUrl, revision) {
+  assertNonEmptyString(packageFolder, "packageFolder");
+  assertNonEmptyString(repoUrl, "repoUrl");
+  assertNonEmptyString(revision, "revision");
+
+  const packageJsonPath = path.resolve(packageFolder, "package.json");
+  const packageJson = /** @type {PackageManifest} */ (
+    readPackageJson(packageJsonPath)
+  );
+  const existingRepository =
+    packageJson.repository &&
+    typeof packageJson.repository === "object" &&
+    !Array.isArray(packageJson.repository)
+      ? packageJson.repository
+      : {};
+
+  packageJson.repository = {
+    ...existingRepository,
+    type: "git",
+    url: repoUrl,
+    revision,
+  };
+
+  fs.writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+  );
+
+  return /** @type {PackageManifest & {repository: RepositoryMetadata}} */ (
+    packageJson
+  );
+};
+
+if (require.main === module) {
+  if (process.argv.length < 5) {
+    logError(
+      "Usage: node patchPackageRepository.js <package-folder> <repo-url> <revision>",
+    );
+    process.exit(1);
+  }
+
+  try {
+    patchPackageRepository(process.argv[2], process.argv[3], process.argv[4]);
+    console.log("Patched package repository metadata");
+  } catch (err) {
+    logError(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  patchPackageRepository,
+};

--- a/test/test-patchPackageRepository.js
+++ b/test/test-patchPackageRepository.js
@@ -1,0 +1,115 @@
+/* eslint-disable no-undef */
+require("should");
+const fs = require("fs");
+const path = require("path");
+const {
+  getTmpDir,
+  createTmpDir,
+  removeTmpDir,
+  writeJsonFile,
+} = require("./utils");
+const { patchPackageRepository } = require("../patchPackageRepository");
+
+describe("patchPackageRepository.js", function () {
+  const tmpDir = getTmpDir("test-patch-package-repository");
+  const repoUrl = "https://github.com/openupm/test-package";
+  const revision = "0123456789abcdef0123456789abcdef01234567";
+
+  beforeEach(function () {
+    removeTmpDir("test-patch-package-repository");
+    createTmpDir("test-patch-package-repository");
+  });
+
+  afterEach(function () {
+    removeTmpDir("test-patch-package-repository");
+  });
+
+  it("adds repository metadata when missing", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+    });
+
+    const result = patchPackageRepository(tmpDir, repoUrl, revision);
+
+    result.repository.should.deepEqual({
+      type: "git",
+      url: repoUrl,
+      revision,
+    });
+
+    const saved = JSON.parse(
+      fs.readFileSync(path.resolve(tmpDir, "package.json"), "utf8"),
+    );
+    saved.repository.should.deepEqual(result.repository);
+  });
+
+  it("replaces string repository metadata", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+      repository: "https://example.invalid/old.git",
+    });
+
+    const result = patchPackageRepository(tmpDir, repoUrl, revision);
+
+    result.repository.should.deepEqual({
+      type: "git",
+      url: repoUrl,
+      revision,
+    });
+  });
+
+  it("preserves extra object repository metadata", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+      repository: {
+        type: "git",
+        url: "https://example.invalid/old.git",
+        directory: "Packages/package-a",
+      },
+    });
+
+    const result = patchPackageRepository(tmpDir, repoUrl, revision);
+
+    result.repository.should.deepEqual({
+      type: "git",
+      url: repoUrl,
+      revision,
+      directory: "Packages/package-a",
+    });
+  });
+
+  it("preserves unrelated manifest fields", function () {
+    writeJsonFile(path.resolve(tmpDir, "package.json"), {
+      name: "package-a",
+      version: "1.0.0",
+      displayName: "Package A",
+      dependencies: {
+        "package-b": "2.0.0",
+      },
+    });
+
+    const result = patchPackageRepository(tmpDir, repoUrl, revision);
+
+    result.name.should.equal("package-a");
+    result.version.should.equal("1.0.0");
+    result.displayName.should.equal("Package A");
+    result.dependencies.should.deepEqual({
+      "package-b": "2.0.0",
+    });
+  });
+
+  it("rejects a missing package manifest", function () {
+    (() => patchPackageRepository(tmpDir, repoUrl, revision)).should.throw(
+      /ENOENT/,
+    );
+  });
+
+  it("rejects an invalid package manifest", function () {
+    fs.writeFileSync(path.resolve(tmpDir, "package.json"), "{");
+
+    (() => patchPackageRepository(tmpDir, repoUrl, revision)).should.throw();
+  });
+});


### PR DESCRIPTION
## Summary
- patch git-sourced package manifests with repository metadata before npm pack
- include the checked-out Git HEAD as repository.revision
- assert repository metadata in the Verdaccio e2e publish path

## Validation
- npm test
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:e2e:azure (Azure build 69229)