### PR TITLE
fix: fetch GitHub LFS over HTTPS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,7 @@ stages:
           - script: |
               set -euo pipefail
               node configureGitLfsUrl.js "$(repoDir)"
-              git submodule foreach --recursive 'node "$(Build.SourcesDirectory)/configureGitLfsUrl.js" "."'
+              git -C "$(repoDir)" submodule foreach --recursive 'node "$(Build.SourcesDirectory)/configureGitLfsUrl.js" "."'
             displayName: "Configure Git LFS transport"
             condition: eq(variables['packageSourceMode'], 'git')
             env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
           - script: |
               set -euo pipefail
               echo "Cloning $(repoUrl) @ $(repoBranch)"
-              GIT_CLONE_PROTECTION_ACTIVE=false git \
+              GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git \
                 -c init.templateDir=/dev/null \
                 -c core.hooksPath=/dev/null \
                 clone --recursive --shallow-submodules --depth 1 --branch "$(repoBranch)" "$(repoUrl)" "$(repoDir)"
@@ -154,9 +154,20 @@ stages:
 
           - script: |
               set -euo pipefail
+              node configureGitLfsUrl.js "$(repoDir)"
+              git submodule foreach --recursive 'node "$(Build.SourcesDirectory)/configureGitLfsUrl.js" "."'
+            displayName: "Configure Git LFS transport"
+            condition: eq(variables['packageSourceMode'], 'git')
+            env:
+              HOME: $(gitHomeDir)
+              XDG_CONFIG_HOME: $(gitConfigDir)
+
+          - script: |
+              set -euo pipefail
               cd "$(repoDir)"
               echo "Fetching Git LFS objects for $(repoDir)"
               git lfs pull
+              git lfs checkout
             displayName: "Fetch Git LFS"
             condition: eq(variables['packageSourceMode'], 'git')
             env:
@@ -167,7 +178,7 @@ stages:
               set -euo pipefail
               cd "$(repoDir)"
               echo "Fetching Git LFS objects for submodules in $(repoDir)"
-              git submodule foreach --recursive 'git lfs pull'
+              git submodule foreach --recursive 'git lfs pull && git lfs checkout'
             displayName: "Fetch submodule Git LFS"
             condition: eq(variables['packageSourceMode'], 'git')
             env:

--- a/configureGitLfsUrl.js
+++ b/configureGitLfsUrl.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const { execFileSync } = require("child_process");
+
+/**
+ * @param {string} repoUrl
+ * @returns {string | null}
+ */
+function getGitHubLfsUrl(repoUrl) {
+  let url;
+  try {
+    url = new URL(repoUrl);
+  } catch {
+    const scpMatch = repoUrl.match(
+      /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
+    );
+    if (!scpMatch) return null;
+    return `https://github.com/${scpMatch[1]}/${scpMatch[2]}.git/info/lfs`;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "ssh:") return null;
+  if (url.hostname.toLowerCase() !== "github.com") return null;
+  if (url.protocol === "ssh:" && url.username && url.username !== "git") {
+    return null;
+  }
+
+  const parts = url.pathname.replace(/^\/+|\/+$/g, "").split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+
+  const repoName = parts[1].replace(/\.git$/i, "");
+  return `https://github.com/${parts[0]}/${repoName}.git/info/lfs`;
+}
+
+/**
+ * @param {string} repoDir
+ * @returns {string}
+ */
+function getOriginUrl(repoDir) {
+  return execFileSync(
+    "git",
+    ["-C", repoDir, "config", "--get", "remote.origin.url"],
+    {
+      encoding: "utf8",
+    },
+  ).trim();
+}
+
+/**
+ * @param {string} repoDir
+ * @param {string} lfsUrl
+ */
+function setGitLfsUrl(repoDir, lfsUrl) {
+  execFileSync("git", ["-C", repoDir, "config", "--local", "lfs.url", lfsUrl], {
+    stdio: "inherit",
+  });
+}
+
+/**
+ * @param {string} repoDir
+ * @returns {string | null}
+ */
+function configureGitLfsUrl(repoDir) {
+  const originUrl = getOriginUrl(repoDir);
+  const lfsUrl = getGitHubLfsUrl(originUrl);
+  if (!lfsUrl) return null;
+
+  setGitLfsUrl(repoDir, lfsUrl);
+  return lfsUrl;
+}
+
+function main() {
+  const repoDir = process.argv[2] || ".";
+  const lfsUrl = configureGitLfsUrl(repoDir);
+  if (lfsUrl) {
+    console.log(`Configured Git LFS URL for GitHub remote: ${lfsUrl}`);
+  } else {
+    console.log(
+      "Repository remote is not a github.com URL; leaving Git LFS URL unchanged.",
+    );
+  }
+}
+
+module.exports = {
+  configureGitLfsUrl,
+  getGitHubLfsUrl,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/test/test-configureGitLfsUrl.js
+++ b/test/test-configureGitLfsUrl.js
@@ -1,0 +1,36 @@
+"use strict";
+/* global describe, it */
+
+const should = require("should");
+
+const { getGitHubLfsUrl } = require("../configureGitLfsUrl");
+
+describe("configureGitLfsUrl.js", function () {
+  it("normalizes HTTPS GitHub remotes to the Git LFS endpoint", function () {
+    getGitHubLfsUrl("https://github.com/bluecadet/unity-packages").should.equal(
+      "https://github.com/bluecadet/unity-packages.git/info/lfs",
+    );
+    getGitHubLfsUrl(
+      "https://github.com/bluecadet/unity-packages.git",
+    ).should.equal("https://github.com/bluecadet/unity-packages.git/info/lfs");
+  });
+
+  it("normalizes GitHub SSH remotes to the public HTTPS Git LFS endpoint", function () {
+    getGitHubLfsUrl(
+      "ssh://git@github.com/bluecadet/unity-packages.git",
+    ).should.equal("https://github.com/bluecadet/unity-packages.git/info/lfs");
+    getGitHubLfsUrl("git@github.com:bluecadet/unity-packages.git").should.equal(
+      "https://github.com/bluecadet/unity-packages.git/info/lfs",
+    );
+  });
+
+  it("does not rewrite non-GitHub remotes", function () {
+    should(
+      getGitHubLfsUrl("https://gitlab.com/bluecadet/unity-packages"),
+    ).equal(null);
+    should(
+      getGitHubLfsUrl("https://github.example.com/bluecadet/unity-packages"),
+    ).equal(null);
+    should(getGitHubLfsUrl("file:///tmp/unity-packages")).equal(null);
+  });
+});


### PR DESCRIPTION
## Summary
- disable LFS smudge during git package clone so repository-level LFS config can be adjusted before object download
- configure github.com remotes to use the public HTTPS Git LFS endpoint before pulling LFS objects
- add unit coverage for GitHub HTTPS, GitHub SSH, and non-GitHub remote handling

## Validation
- npm test
- npm run lint
- npm run format:check
- npm run typecheck
- Azure e2e fixture for com.bluecadet.utils@0.1.6 published successfully to the temporary Verdaccio registry